### PR TITLE
閉じるボタンの位置とデザインを変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonchidot-react-modal-dialog",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A simple, idiomatic, and declarative way to launch modal dialogs in ReactJS",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonchidot-react-modal-dialog",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A simple, idiomatic, and declarative way to launch modal dialogs in ReactJS",
   "repository": {
     "type": "git",

--- a/src/CloseTextButton.js
+++ b/src/CloseTextButton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+// Done in SVG so we can avoid importing any CSS
+
+const CloseTextButton = () => {
+  const style = {
+    padding: '10px',
+    color: 'gray'
+  }
+  return <button style={style}>閉じる</button>
+};
+
+export default CloseTextButton;

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import dynamics from 'dynamics.js';
 import centerComponent from 'react-center-component';
 import useSheet from './useSheet';
-import CloseCircle from './CloseCircle';
+import CloseTextButton from './CloseTextButton';
 import EventStack from 'active-event-stack';
 import keycode from 'keycode';
 
@@ -20,18 +20,11 @@ import keycode from 'keycode';
   },
   'closeButton': {
     position: 'absolute',
-    top: 0,
-    left: -50,
+    bottom: 0,
+    left: 0,
     display: 'block',
-    width: 40,
-    height: 40,
-    transition: 'transform 0.1s',
-    // backgroundImage: require('../images/modal-dialog-close.png'),
-    // backgroundRepeat: 'no-repeat',
-    // backgroundSize: '40px 40px',
-    '&:hover': {
-      transform: 'scale(1.1)',
-    },
+    padding: '10px',
+    margin: '10px',
   },
 })
 // This decorator centers the dialog
@@ -176,7 +169,7 @@ export default class ModalDialog extends React.Component {
       {
         onClose ?
         <a className={classes.closeButton} onClick={onClose}>
-          <CloseCircle diameter={40}/>
+          <CloseTextButton />
         </a> :
         null
       }


### PR DESCRIPTION
https://github.com/tonchidot/walk-through-vr/issues/51 の修正です。

walkthroughの方と合わせて動作確認する場合は、
1. react-modal-dialogをgit cloneしてローカルのどこかに置く。npm run buildする。
2. walkthroughの方に移動してpackage.jsonからreact-modal-dialogの記述消す
3. walkthroughの方で 一旦npm installする
4. walkthroughの方でnpm install <ローカルに置いたreact-modal-dialogのPATH>
5. サーバー起動

でいけると思います。（注）もっとスマートな方法があるかもしれません。
