### PR TITLE
Fix ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonchidot-react-modal-dialog",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A simple, idiomatic, and declarative way to launch modal dialogs in ReactJS",
   "repository": {
     "type": "git",

--- a/src/ModalBackground.js
+++ b/src/ModalBackground.js
@@ -58,6 +58,7 @@ export default class ModalBackground extends React.Component {
       width: '100%',
       transition: `opacity ${this.props.duration / 1000}s`,
       WebkitTransition: `opacity ${this.props.duration / 1000}s`,
+      cursor: 'pointer'
     };
 
     const containerStyle = {
@@ -70,7 +71,8 @@ export default class ModalBackground extends React.Component {
       width: '100%',
       transition: `opacity ${this.props.duration / 1000}s`,
       WebkitTransition: `opacity ${this.props.duration / 1000}s`,
-      backgroundColor: 'transparent'
+      backgroundColor: 'transparent',
+      cursor: 'pointer'
     };
 
     const style = {
@@ -84,7 +86,7 @@ export default class ModalBackground extends React.Component {
 
     return <div style={style}>
       <div style={overlayStyle}/>
-      <button style={containerStyle}>{this.getChild()}</button>
+      <div style={containerStyle}>{this.getChild()}</div>
     </div>;
   }
 }


### PR DESCRIPTION
IE11において、ダイアログ内のクリックイベントが正しく発動しない状態だったので修正。
https://github.com/qimingweng/react-modal-dialog/pull/26
オリジナルのPR内で提唱されているアプローチに変更したら、IE11でもiOSでも動作しました。

どうやら、button内にさらにbuttonやクリッカブル要素を配置するようなレイアウトには問題あるようで、reactのwarningも出てましたがこれで消えます。
